### PR TITLE
明度スライダー追加（表示はしない）

### DIFF
--- a/Sources/CustomViewFeature/ColorPickerView.swift
+++ b/Sources/CustomViewFeature/ColorPickerView.swift
@@ -70,7 +70,7 @@ public struct SaturationSlider: View {
   public var body: some View {
     GeometryReader { geometry in
       ZStack(alignment: .leading) {
-        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: hue, saturation: Double($0) / 100.0, brightness: 1)}),
+        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: hue, saturation: (100 - Double($0)) / 100.0, brightness: 1)}),
                        startPoint: .leading,
                        endPoint: .trailing)
           .overlay(
@@ -87,11 +87,11 @@ public struct SaturationSlider: View {
             .frame(width: height - 8, height: height - 8)
         }
         .offset(x: height / 2)
-        .position(x: CGFloat(self.saturation) * (geometry.size.width - height), y: geometry.size.height / 2)
+        .position(x: CGFloat(1 - self.saturation) * (geometry.size.width - height), y: geometry.size.height / 2)
         .gesture(
           DragGesture()
             .onChanged { gesture in
-              let newValue = gesture.location.x / geometry.size.width
+              let newValue = (geometry.size.width - gesture.location.x) / geometry.size.width
               self.saturation = min(max(Double(newValue), 0), 1)
             }
         )
@@ -117,7 +117,7 @@ public struct BrightnessSlider: View {
   public var body: some View {
     GeometryReader { geometry in
       ZStack(alignment: .leading) {
-        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: hue, saturation: 1, brightness: Double($0) / 100.0)}), startPoint: .leading, endPoint: .trailing)
+        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: hue, saturation: 1, brightness: (100 - Double($0)) / 100.0)}), startPoint: .leading, endPoint: .trailing)
           .overlay(
             RoundedRectangle(cornerRadius: height / 2)
               .stroke(Color(hue: hue, saturation: 1, brightness: 1), lineWidth: 4)
@@ -132,11 +132,11 @@ public struct BrightnessSlider: View {
             .frame(width: height - 8, height: height - 8)
         }
         .offset(x: height / 2)
-        .position(x: CGFloat(self.brightness) * (geometry.size.width - height), y: geometry.size.height / 2)
+        .position(x: CGFloat(1 - self.brightness) * (geometry.size.width - height), y: geometry.size.height / 2)
         .gesture(
           DragGesture()
             .onChanged { gesture in
-              let newValue = gesture.location.x / geometry.size.width
+              let newValue = (geometry.size.width - gesture.location.x) / geometry.size.width
               self.brightness = min(max(Double(newValue), 0), 1)
             }
         )
@@ -159,15 +159,6 @@ public struct ColorPickerView: View {
 
   public var body: some View {
     VStack(spacing: 20) {
-      // 選択された色の表示
-//      RoundedRectangle(cornerRadius: 20)
-//        .fill(Color(hue: hue, saturation: saturation, brightness: 1))
-//        .frame(height: 100)
-//        .overlay(
-//          RoundedRectangle(cornerRadius: 20)
-//            .stroke(Color.white, lineWidth: 4)
-//        )
-//        .shadow(radius: 5)
       // 色相スライダー
       ColorSlider(hue: $hue, saturation: $saturation, brightness: $brightness, height: sliderHeight)
         .frame(height: sliderHeight)
@@ -178,9 +169,15 @@ public struct ColorPickerView: View {
         .frame(height: sliderHeight)
         .clipShape(.rect(cornerRadius: sliderHeight / 2))
       // 明度スライダー
-      BrightnessSlider(hue: $hue, saturation: $saturation, brightness: $brightness, height: sliderHeight)
-        .frame(height: sliderHeight)
-        .clipShape(.rect(cornerRadius: sliderHeight / 2))
+//      BrightnessSlider(hue: $hue, saturation: $saturation, brightness: $brightness, height: sliderHeight)
+//        .frame(height: sliderHeight)
+//        .clipShape(.rect(cornerRadius: sliderHeight / 2))
+      // 白 or 黒
+      
+      // TODO: Brightnessのデータ管理をisBlackのフラグで行うように変更(UserDefaultsとEntity)
+      // FIXME: brightnessの値はisBlackがtrueなら0, そうじゃないなら1
+      // TODO: 白or黒のToggleかButton実装、
+      
     }
     .padding()
   }

--- a/Sources/CustomViewFeature/ColorPickerView.swift
+++ b/Sources/CustomViewFeature/ColorPickerView.swift
@@ -173,11 +173,10 @@ public struct ColorPickerView: View {
 //        .frame(height: sliderHeight)
 //        .clipShape(.rect(cornerRadius: sliderHeight / 2))
       // 白 or 黒
-      
-      // TODO: Brightnessのデータ管理をisBlackのフラグで行うように変更(UserDefaultsとEntity)
-      // FIXME: → White or Custom or Blackのようなenumにしたい。できれば
-      // FIXME: brightnessの値はisBlackがtrueなら0, そうじゃないなら1
-      // TODO: 白or黒のToggleかButton実装、
+      /// Brightnessのデータ管理をisBlackのフラグで行うように変更(UserDefaultsとEntity)
+      /// → White or Custom or Blackのようなenumにしたい。できれば
+      /// brightnessの値はisBlackがtrueなら0, そうじゃないなら1
+      /// 白or黒のToggleかButton実装
       
     }
     .padding()

--- a/Sources/CustomViewFeature/ColorPickerView.swift
+++ b/Sources/CustomViewFeature/ColorPickerView.swift
@@ -10,17 +10,23 @@ import SwiftUI
 
 struct ColorSlider: View {
   @Binding var hue: Double
+  @Binding var saturation: Double
+  @Binding var brightness: Double
   let height: CGFloat
 
-  init(hue: Binding<Double>, height: CGFloat) {
+  init(hue: Binding<Double>, saturation: Binding<Double>, brightness: Binding<Double>, height: CGFloat) {
     self._hue = hue
+    self._saturation = saturation
+    self._brightness = brightness
     self.height = height
   }
 
   var body: some View {
     GeometryReader { geometry in
       ZStack(alignment: .leading) {
-        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: Double($0) / 100.0, saturation: 1, brightness: 1)}), startPoint: .leading, endPoint: .trailing)
+        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: Double($0) / 100.0, saturation: 1, brightness: 1)}),
+                       startPoint: .leading,
+                       endPoint: .trailing)
           .overlay(
             RoundedRectangle(cornerRadius: height / 2)
               .stroke(Color(hue: hue, saturation: 1, brightness: 1), lineWidth: 4)
@@ -31,7 +37,7 @@ struct ColorSlider: View {
             .fill(.white)
             .frame(width: height, height: height)
           Circle()
-            .fill(Color(hue: hue, saturation: 1, brightness: 1))
+            .fill(Color(hue: hue, saturation: saturation, brightness: brightness))
             .frame(width: height - 8, height: height - 8)
         }
         .offset(x: height / 2)
@@ -51,18 +57,22 @@ struct ColorSlider: View {
 public struct SaturationSlider: View {
   @Binding var hue: Double
   @Binding var saturation: Double
+  @Binding var brightness: Double
   let height: CGFloat
 
-  init(hue: Binding<Double>, saturation: Binding<Double>, height: CGFloat) {
+  init(hue: Binding<Double>, saturation: Binding<Double>, brightness: Binding<Double>, height: CGFloat) {
     self._hue = hue
     self._saturation = saturation
+    self._brightness = brightness
     self.height = height
   }
 
   public var body: some View {
     GeometryReader { geometry in
       ZStack(alignment: .leading) {
-        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: hue, saturation: Double($0) / 100.0, brightness: 1)}), startPoint: .leading, endPoint: .trailing)
+        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: hue, saturation: Double($0) / 100.0, brightness: 1)}),
+                       startPoint: .leading,
+                       endPoint: .trailing)
           .overlay(
             RoundedRectangle(cornerRadius: height / 2)
               .stroke(Color(hue: hue, saturation: 1, brightness: 1), lineWidth: 4)
@@ -73,7 +83,7 @@ public struct SaturationSlider: View {
             .fill(.white)
             .frame(width: height, height: height)
           Circle()
-            .fill(Color(hue: hue, saturation: saturation, brightness: 1))
+            .fill(Color(hue: hue, saturation: saturation, brightness: brightness))
             .frame(width: height - 8, height: height - 8)
         }
         .offset(x: height / 2)
@@ -90,14 +100,61 @@ public struct SaturationSlider: View {
   }
 }
 
+// 明度ピッカー
+public struct BrightnessSlider: View {
+  @Binding var hue: Double
+  @Binding var saturation: Double
+  @Binding var brightness: Double
+  let height: CGFloat
+
+  init(hue: Binding<Double>, saturation: Binding<Double>, brightness: Binding<Double>, height: CGFloat) {
+    self._hue = hue
+    self._saturation = saturation
+    self._brightness = brightness
+    self.height = height
+  }
+
+  public var body: some View {
+    GeometryReader { geometry in
+      ZStack(alignment: .leading) {
+        LinearGradient(gradient: Gradient(colors: (0..<100).map { Color(hue: hue, saturation: 1, brightness: Double($0) / 100.0)}), startPoint: .leading, endPoint: .trailing)
+          .overlay(
+            RoundedRectangle(cornerRadius: height / 2)
+              .stroke(Color(hue: hue, saturation: 1, brightness: 1), lineWidth: 4)
+          )
+        
+        ZStack(alignment: .center) {
+          Circle()
+            .fill(.white)
+            .frame(width: height, height: height)
+          Circle()
+            .fill(Color(hue: hue, saturation: saturation, brightness: brightness))
+            .frame(width: height - 8, height: height - 8)
+        }
+        .offset(x: height / 2)
+        .position(x: CGFloat(self.brightness) * (geometry.size.width - height), y: geometry.size.height / 2)
+        .gesture(
+          DragGesture()
+            .onChanged { gesture in
+              let newValue = gesture.location.x / geometry.size.width
+              self.brightness = min(max(Double(newValue), 0), 1)
+            }
+        )
+      }
+    }
+  }
+}
+
 public struct ColorPickerView: View {
   @Binding private var hue: Double
   @Binding private var saturation: Double
+  @Binding private var brightness: Double
   private let sliderHeight: CGFloat = 32
 
-  public init(hue: Binding<Double>, saturation: Binding<Double>) {
+  public init(hue: Binding<Double>, saturation: Binding<Double>, brightness: Binding<Double>) {
     self._hue = hue
     self._saturation = saturation
+    self._brightness = brightness
   }
 
   public var body: some View {
@@ -112,12 +169,16 @@ public struct ColorPickerView: View {
 //        )
 //        .shadow(radius: 5)
       // 色相スライダー
-      ColorSlider(hue: $hue, height: sliderHeight)
+      ColorSlider(hue: $hue, saturation: $saturation, brightness: $brightness, height: sliderHeight)
         .frame(height: sliderHeight)
         .clipShape(.rect(cornerRadius: sliderHeight / 2))
         .accentColor(.gray)
       // 彩度スライダー
-      SaturationSlider(hue: $hue, saturation: $saturation, height: sliderHeight)
+      SaturationSlider(hue: $hue, saturation: $saturation, brightness: $brightness, height: sliderHeight)
+        .frame(height: sliderHeight)
+        .clipShape(.rect(cornerRadius: sliderHeight / 2))
+      // 明度スライダー
+      BrightnessSlider(hue: $hue, saturation: $saturation, brightness: $brightness, height: sliderHeight)
         .frame(height: sliderHeight)
         .clipShape(.rect(cornerRadius: sliderHeight / 2))
     }

--- a/Sources/CustomViewFeature/ColorPickerView.swift
+++ b/Sources/CustomViewFeature/ColorPickerView.swift
@@ -175,6 +175,7 @@ public struct ColorPickerView: View {
       // 白 or 黒
       
       // TODO: Brightnessのデータ管理をisBlackのフラグで行うように変更(UserDefaultsとEntity)
+      // FIXME: → White or Custom or Blackのようなenumにしたい。できれば
       // FIXME: brightnessの値はisBlackがtrueなら0, そうじゃないなら1
       // TODO: 白or黒のToggleかButton実装、
       

--- a/Sources/Entities/NoteItem.swift
+++ b/Sources/Entities/NoteItem.swift
@@ -18,16 +18,17 @@ public class NoteItem: Identifiable {
   
   public var hue: Double
   public var saturation: Double
+  public var brightness: Double
   
   public var systemIconName: String
   public var blockTypeValue: String
 
   public var uiColor: UIColor {
-    UIColor(hue: CGFloat(hue), saturation: CGFloat(saturation), brightness: 1, alpha: 1)
+    UIColor(hue: CGFloat(hue), saturation: CGFloat(saturation), brightness: CGFloat(brightness), alpha: 1)
   }
 
   public var color: Color {
-    Color(hue: hue, saturation: saturation, brightness: 1)
+    Color(hue: hue, saturation: saturation, brightness: brightness)
   }
 
   public var blockType: BlockType {
@@ -39,11 +40,12 @@ public class NoteItem: Identifiable {
     }
   }
 
-  public init(title: String, content: String, hue: Double, saturation: Double, systemIconName: String, blockType: BlockType) {
+  public init(title: String, content: String, hue: Double, saturation: Double, brightness: Double, systemIconName: String, blockType: BlockType) {
     self.title = title
     self.content = content
     self.hue = hue
     self.saturation = saturation
+    self.brightness = brightness
     self.systemIconName = systemIconName
     self.blockTypeValue = blockType.rawValue
   }

--- a/Sources/Entities/NoteItem.swift
+++ b/Sources/Entities/NoteItem.swift
@@ -23,9 +23,9 @@ public class NoteItem: Identifiable {
   public var systemIconName: String
   public var blockTypeValue: String
 
-  public var uiColor: UIColor {
-    UIColor(hue: CGFloat(hue), saturation: CGFloat(saturation), brightness: CGFloat(brightness), alpha: 1)
-  }
+//  public var uiColor: UIColor {
+//    UIColor(hue: CGFloat(hue), saturation: CGFloat(saturation), brightness: CGFloat(brightness), alpha: 1)
+//  }
 
   public var color: Color {
     Color(hue: hue, saturation: saturation, brightness: brightness)

--- a/Sources/Extensions/Color+Extension.swift
+++ b/Sources/Extensions/Color+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  Color+Extension.swift
+//  BlockNotes
+//
+//  Created by Kei on 2024/08/12.
+//
+
+import SwiftUI
+import UIKit
+
+extension Color {
+  public var foregroundColor: Color {
+    let uiColor = UIColor(self)
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+  
+    let luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+    return luminance > 0.5 ? .black : .white
+  }
+}

--- a/Sources/Extensions/UIColor+Extension.swift
+++ b/Sources/Extensions/UIColor+Extension.swift
@@ -8,18 +8,17 @@
 import UIKit
 
 extension UIColor {
-    public func toHexString() -> String {
-        var r: CGFloat = 0
-        var g: CGFloat = 0
-        var b: CGFloat = 0
-        var a: CGFloat = 0
-        
-        getRed(&r, green: &g, blue: &b, alpha: &a)
-        
-        let rgb: Int = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
-        
-        return String(format: "%06X", rgb)
-    }
+  // カラーコード作成メソッド。使ってないけど一応残しとく
+  public func toHexString() -> String {
+    var r: CGFloat = 0
+    var g: CGFloat = 0
+    var b: CGFloat = 0
+    var a: CGFloat = 0
+    
+    getRed(&r, green: &g, blue: &b, alpha: &a)
+    let rgb: Int = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
+    return String(format: "%06X", rgb)
+  }
 
   public func textColor() -> UIColor {
     var red: CGFloat = 0

--- a/Sources/Extensions/UIColor+Extension.swift
+++ b/Sources/Extensions/UIColor+Extension.swift
@@ -20,16 +20,23 @@ extension UIColor {
     return String(format: "%06X", rgb)
   }
 
-  public func textColor() -> UIColor {
-    var red: CGFloat = 0
-    var green: CGFloat = 0
-    var blue: CGFloat = 0
-    var alpha: CGFloat = 0
+  // TODO: Color+Extensionの方で代用できているからそのうち消す
+//  public func textColor() -> UIColor {
+//    var red: CGFloat = 0
+//    var green: CGFloat = 0
+//    var blue: CGFloat = 0
+//    var alpha: CGFloat = 0
+//
+//    self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+//
+//    let luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+//
+//    return luminance > 0.5 ? .black : .white
+//  }
 
-    self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-
-    let luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
-
-    return luminance > 0.5 ? .black : .white
+  var hsb: (hue: Double, saturation: Double, brightness: Double) {
+    var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+    self.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+    return (Double(h), Double(s), Double(b))
   }
 }

--- a/Sources/HomeFeature/BlockItemView.swift
+++ b/Sources/HomeFeature/BlockItemView.swift
@@ -48,13 +48,15 @@ public struct BlockItemView: View {
   private func getForegroundColor(item: NoteItem) -> Color {
     switch item.blockType {
     case .note:
-      return Color(uiColor: item.uiColor.textColor())
+      return item.color.foregroundColor
     case .add:
-      let uiColor = UIColor(hue: settings.plusBlockHue, saturation: settings.plusBlockSaturation, brightness: 1, alpha: 1)
-      return Color(uiColor: uiColor.textColor())
+      return Color(hue: settings.plusBlockHue,
+                   saturation: settings.plusBlockSaturation,
+                   brightness: settings.plusBlockBrightness).foregroundColor
     case .setting:
-      let uiColor = UIColor(hue: settings.settingBlockHue, saturation: settings.settingBlockSaturation, brightness: 1, alpha: 1)
-      return Color(uiColor: uiColor.textColor())
+      return Color(hue: settings.settingBlockHue,
+                   saturation: settings.settingBlockSaturation,
+                   brightness: settings.settingBlockBrightness).foregroundColor
     case .other:
       return settings.isDarkMode ? .black : .white
     }
@@ -65,9 +67,9 @@ public struct BlockItemView: View {
     case .note:
       return item.color
     case .add:
-      return Color(hue: settings.plusBlockHue, saturation: settings.plusBlockSaturation, brightness: 1)
+      return Color(hue: settings.plusBlockHue, saturation: settings.plusBlockSaturation, brightness: settings.plusBlockBrightness)
     case .setting:
-      return Color(hue: settings.settingBlockHue, saturation: settings.settingBlockSaturation, brightness: 1)
+      return Color(hue: settings.settingBlockHue, saturation: settings.settingBlockSaturation, brightness: settings.settingBlockBrightness)
     case .other:
       return settings.isDarkMode ? .white : .black
     }

--- a/Sources/HomeFeature/HomeView.swift
+++ b/Sources/HomeFeature/HomeView.swift
@@ -81,10 +81,12 @@ public struct HomeView: View {
       .fullScreenCover(isPresented: $isAddingNote) {
         let initialHue: Double = settings.isDarkMode ? 0 : 1
         let initialSaturation: Double = 1
+        let initialBrightness: Double = 1
         let initialItem: NoteItem = .init(title: "",
                                           content: "",
                                           hue: initialHue,
                                           saturation: initialSaturation,
+                                          brightness: initialBrightness,
                                           systemIconName: "house",
                                           blockType: .note)
         NoteView(noteItem: initialItem, isEditNote: false) { item in
@@ -130,6 +132,7 @@ extension HomeView {
                                   content: "",
                                   hue: 0,
                                   saturation: 1,
+                                  brightness: 1,
                                   systemIconName: "plus",
                                   blockType: .add)
     let addItemView = BlockItemView(item: addItem) { _ in
@@ -146,6 +149,7 @@ extension HomeView {
                                       content: "",
                                       hue: 0,
                                       saturation: 1,
+                                      brightness: 1,
                                       systemIconName: "gearshape",
                                       blockType: .setting)
     let settingItemView = BlockItemView(item: settingItem) { _ in

--- a/Sources/NoteFeature/EditIconView.swift
+++ b/Sources/NoteFeature/EditIconView.swift
@@ -39,7 +39,7 @@ public struct EditIconView: View {
             .resizable()
             .aspectRatio(contentMode: .fit)
             .padding(20)
-            .foregroundStyle(Color(uiColor: UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).textColor()))
+            .foregroundStyle(backGroundColor.foregroundColor)
         }
         .frame(width: 80, height: 80)
         .background(backGroundColor)

--- a/Sources/NoteFeature/EditIconView.swift
+++ b/Sources/NoteFeature/EditIconView.swift
@@ -16,14 +16,15 @@ public struct EditIconView: View {
 
   @State private var hue: Double = 0
   @State private var saturation: Double = 1
+  @State private var brightness: Double = 1
   
   @State private var systemImageString: String = ""
 
   private var backGroundColor: Color {
-    Color(hue: hue, saturation: saturation, brightness: 1)
+    Color(hue: hue, saturation: saturation, brightness: brightness)
   }
   private var hexColorText: String {
-    UIColor(hue: hue, saturation: saturation, brightness: 1, alpha: 1).toHexString()
+    UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).toHexString()
   }
 
   public init(noteItem: NoteItem) {
@@ -41,14 +42,14 @@ public struct EditIconView: View {
             .resizable()
             .aspectRatio(contentMode: .fit)
             .padding(20)
-            .foregroundStyle(Color(uiColor: UIColor(hue: hue, saturation: saturation, brightness: 1, alpha: 1).textColor()))
+            .foregroundStyle(Color(uiColor: UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).textColor()))
         }
         .frame(width: 80, height: 80)
         .background(backGroundColor)
         .clipShape(.rect(cornerRadius: 8))
         .padding(.trailing, 32)
         // カラーピッカー
-        ColorPickerView(hue: $hue, saturation: $saturation)
+        ColorPickerView(hue: $hue, saturation: $saturation, brightness: $brightness)
         // アイコン選択
         SymbolSelectView(selectedSymbol: $systemImageString)
       }

--- a/Sources/NoteFeature/EditIconView.swift
+++ b/Sources/NoteFeature/EditIconView.swift
@@ -23,9 +23,6 @@ public struct EditIconView: View {
   private var backGroundColor: Color {
     Color(hue: hue, saturation: saturation, brightness: brightness)
   }
-  private var hexColorText: String {
-    UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).toHexString()
-  }
 
   public init(noteItem: NoteItem) {
     self.noteItem = noteItem

--- a/Sources/NoteFeature/NoteView.swift
+++ b/Sources/NoteFeature/NoteView.swift
@@ -58,7 +58,7 @@ public struct NoteView: View {
             Image(systemName: noteItem.systemIconName)
               .resizable()
               .aspectRatio(contentMode: .fit)
-              .foregroundStyle(Color(uiColor: noteItem.uiColor.textColor()))
+              .foregroundStyle(noteItem.color.foregroundColor)
               .padding(12)
           }
           .frame(width: 48, height: 48)

--- a/Sources/SettingsFeature/AppSettingsService.swift
+++ b/Sources/SettingsFeature/AppSettingsService.swift
@@ -33,10 +33,14 @@ public class AppSettingsService: ObservableObject {
       userDefaults.set(plusBlockHue, forKey: "plusBlockHue")
     }
   }
-
   @Published public var plusBlockSaturation: Double {
     didSet {
       userDefaults.set(plusBlockSaturation, forKey: "plusBlockSaturation")
+    }
+  }
+  @Published public var plusBlockBrightness: Double {
+    didSet {
+      userDefaults.set(plusBlockBrightness, forKey: "plusBlockBrightness")
     }
   }
   
@@ -46,10 +50,14 @@ public class AppSettingsService: ObservableObject {
       userDefaults.set(settingBlockHue, forKey: "settingBlockHue")
     }
   }
-
   @Published public var settingBlockSaturation: Double {
     didSet {
       userDefaults.set(settingBlockSaturation, forKey: "settingBlockSaturation")
+    }
+  }
+  @Published public var settingBlockBrightness: Double {
+    didSet {
+      userDefaults.set(settingBlockBrightness, forKey: "settingBlockBrightness")
     }
   }
 
@@ -66,7 +74,9 @@ public class AppSettingsService: ObservableObject {
     // 初期値設定
     userDefaults.register(defaults: [
       "plusBlockSaturation" : 1.0,
-      "settingBlockSaturation" : 1.0
+      "plusBlockBrightness": 1.0,
+      "settingBlockSaturation" : 1.0,
+      "settingBlockBrightness": 1.0
     ])
     // 設定値取り出し
     self.userDefaults = userDefaults
@@ -76,9 +86,12 @@ public class AppSettingsService: ObservableObject {
     // PlusBlockColor
     self.plusBlockHue = userDefaults.double(forKey: "plusBlockHue")
     self.plusBlockSaturation = userDefaults.double(forKey: "plusBlockSaturation")
+    self.plusBlockBrightness = userDefaults.double(forKey: "plusBlockBrightness")
     // SettingBlockColor
     self.settingBlockHue = userDefaults.double(forKey: "settingBlockHue")
     self.settingBlockSaturation = userDefaults.double(forKey: "settingBlockSaturation")
+    self.settingBlockBrightness = userDefaults.double(forKey: "settingBlockBrightness")
+
     self.fontType = AppFontType(rawValue: userDefaults.string(forKey: "fontType") ?? "system") ?? .system
   }
 

--- a/Sources/SettingsFeature/PlusBlockSettingView.swift
+++ b/Sources/SettingsFeature/PlusBlockSettingView.swift
@@ -15,7 +15,7 @@ public struct PlusBlockSettingView: View {
   @State private var saturation: Double = 1
   @State private var brightness: Double = 1
 
-  private var backGroundColor: Color {
+  private var selectedColor: Color {
     Color(hue: hue, saturation: saturation, brightness: brightness)
   }
 
@@ -31,10 +31,10 @@ public struct PlusBlockSettingView: View {
           .resizable()
           .aspectRatio(contentMode: .fit)
           .padding(24)
-          .foregroundStyle(Color(uiColor: UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).textColor()))
+          .foregroundStyle(selectedColor.foregroundColor)
       }
       .frame(width: 80, height: 80)
-      .background(backGroundColor)
+      .background(selectedColor)
       .clipShape(.rect(cornerRadius: 8))
       .padding(.trailing, 32)
 

--- a/Sources/SettingsFeature/PlusBlockSettingView.swift
+++ b/Sources/SettingsFeature/PlusBlockSettingView.swift
@@ -18,9 +18,6 @@ public struct PlusBlockSettingView: View {
   private var backGroundColor: Color {
     Color(hue: hue, saturation: saturation, brightness: brightness)
   }
-  private var hexColorText: String {
-    UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).toHexString()
-  }
 
   public init() {
   }

--- a/Sources/SettingsFeature/PlusBlockSettingView.swift
+++ b/Sources/SettingsFeature/PlusBlockSettingView.swift
@@ -13,12 +13,13 @@ public struct PlusBlockSettingView: View {
   @EnvironmentObject var settings: AppSettingsService
   @State private var hue: Double = 0
   @State private var saturation: Double = 1
+  @State private var brightness: Double = 1
 
   private var backGroundColor: Color {
-    Color(hue: hue, saturation: saturation, brightness: 1)
+    Color(hue: hue, saturation: saturation, brightness: brightness)
   }
   private var hexColorText: String {
-    UIColor(hue: hue, saturation: saturation, brightness: 1, alpha: 1).toHexString()
+    UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).toHexString()
   }
 
   public init() {
@@ -33,7 +34,7 @@ public struct PlusBlockSettingView: View {
           .resizable()
           .aspectRatio(contentMode: .fit)
           .padding(24)
-          .foregroundStyle(Color(uiColor: UIColor(hue: hue, saturation: saturation, brightness: 1, alpha: 1).textColor()))
+          .foregroundStyle(Color(uiColor: UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).textColor()))
       }
       .frame(width: 80, height: 80)
       .background(backGroundColor)
@@ -41,16 +42,18 @@ public struct PlusBlockSettingView: View {
       .padding(.trailing, 32)
 
       // カラーピッカー
-      ColorPickerView(hue: $hue, saturation: $saturation)
+      ColorPickerView(hue: $hue, saturation: $saturation, brightness: $brightness)
     }
     .padding(.horizontal, 32)
     .onAppear {
       self.hue = settings.plusBlockHue
       self.saturation = settings.plusBlockSaturation
+      self.brightness = settings.plusBlockBrightness
     }
     .onDisappear {
       settings.plusBlockHue = hue
       settings.plusBlockSaturation = saturation
+      settings.plusBlockBrightness = brightness
     }
   }
 }

--- a/Sources/SettingsFeature/SettingBlockSettingView.swift
+++ b/Sources/SettingsFeature/SettingBlockSettingView.swift
@@ -15,7 +15,7 @@ public struct SettingBlockSettingView: View {
   @State private var saturation: Double = 1
   @State private var brightness: Double = 1
 
-  private var backGroundColor: Color {
+  private var selectedColor: Color {
     Color(hue: hue, saturation: saturation, brightness: brightness)
   }
 
@@ -31,10 +31,10 @@ public struct SettingBlockSettingView: View {
           .resizable()
           .aspectRatio(contentMode: .fit)
           .padding(24)
-          .foregroundStyle(Color(uiColor: UIColor(hue: hue, saturation: saturation, brightness: 1, alpha: 1).textColor()))
+          .foregroundStyle(selectedColor.foregroundColor)
       }
       .frame(width: 80, height: 80)
-      .background(backGroundColor)
+      .background(selectedColor)
       .clipShape(.rect(cornerRadius: 8))
       .padding(.trailing, 32)
       

--- a/Sources/SettingsFeature/SettingBlockSettingView.swift
+++ b/Sources/SettingsFeature/SettingBlockSettingView.swift
@@ -13,12 +13,13 @@ public struct SettingBlockSettingView: View {
   @EnvironmentObject var settings: AppSettingsService
   @State private var hue: Double = 0
   @State private var saturation: Double = 1
+  @State private var brightness: Double = 1
 
   private var backGroundColor: Color {
-    Color(hue: hue, saturation: saturation, brightness: 1)
+    Color(hue: hue, saturation: saturation, brightness: brightness)
   }
   private var hexColorText: String {
-    UIColor(hue: hue, saturation: saturation, brightness: 1, alpha: 1).toHexString()
+    UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).toHexString()
   }
 
   public init() {
@@ -41,16 +42,18 @@ public struct SettingBlockSettingView: View {
       .padding(.trailing, 32)
       
       // カラーピッカー
-      ColorPickerView(hue: $hue, saturation: $saturation)
+      ColorPickerView(hue: $hue, saturation: $saturation, brightness: $brightness)
     }
     .padding(.horizontal, 32)
     .onAppear {
       self.hue = settings.settingBlockHue
       self.saturation = settings.settingBlockSaturation
+      self.brightness = settings.settingBlockBrightness
     }
     .onDisappear {
       settings.settingBlockHue = hue
       settings.settingBlockSaturation = saturation
+      settings.settingBlockBrightness = brightness
     }
   }
 }

--- a/Sources/SettingsFeature/SettingBlockSettingView.swift
+++ b/Sources/SettingsFeature/SettingBlockSettingView.swift
@@ -18,9 +18,6 @@ public struct SettingBlockSettingView: View {
   private var backGroundColor: Color {
     Color(hue: hue, saturation: saturation, brightness: brightness)
   }
-  private var hexColorText: String {
-    UIColor(hue: hue, saturation: saturation, brightness: brightness, alpha: 1).toHexString()
-  }
 
   public init() {
   }


### PR DESCRIPTION
明度スライダーを追加

追加したけどユーザビリティ的に使わない方が良さそうなので表示部分をコメントアウトしてる
黒色を選択させたくて明度スライダーを追加したけどユーザー的にめっちゃわかりづらそうだった
iOS18のホーム画面のアイコン変更のようにライトorダークor色調整を選べるようにするのがベストだった

とりあえず黒は選択できない状態でリリース、アップデート後に実装でも良いと思う

![IMG_0474](https://github.com/user-attachments/assets/4f30a777-aabf-4194-bd6f-47036d3a91da)
