### PR TITLE
バグ修正

### DIFF
--- a/App/BlockNotes.xcodeproj/xcshareddata/xcschemes/BlockNotes.xcscheme
+++ b/App/BlockNotes.xcodeproj/xcshareddata/xcschemes/BlockNotes.xcscheme
@@ -54,15 +54,20 @@
          <EnvironmentVariable
             key = "com.apple.CoreData.SQLDebug"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "com.apple.CoreData.Logging.stderr"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "CD_DEBUG_IO"
+            value = "1"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CG_NUMERICS_SHOW_BACKTRACE"
             value = "1"
             isEnabled = "YES">
          </EnvironmentVariable>

--- a/Sources/CustomViewFeature/GravityView.swift
+++ b/Sources/CustomViewFeature/GravityView.swift
@@ -5,36 +5,43 @@
 //  Created by Kei on 2024/07/14.
 //
 
+import InAppPurchaseFeature
 import SwiftUI
 import UIKit
 
 public struct GravityView: UIViewRepresentable {
+  @EnvironmentObject var purchaseManager: InAppPurchaseManager
   // TODO: 要検討：Bindingじゃなくて良いかも
   @Binding var animationViews: [UIView]
   @Binding var angle: CGFloat
+  let viewWidth: CGFloat
+  let viewHeight: CGFloat
+  let isPurchaseProduct: Bool
 
-  public init(animationViews: Binding<[UIView]>, angle: Binding<CGFloat>) {
+  public init(animationViews: Binding<[UIView]>, angle: Binding<CGFloat>, viewWidth: CGFloat, viewHeight: CGFloat, isPurchaseProduct: Bool) {
     self._animationViews = animationViews
     self._angle = angle
+    self.viewWidth = viewWidth
+    self.viewHeight = viewHeight
+    self.isPurchaseProduct = isPurchaseProduct
   }
 
   public func makeUIView(context: Context) -> UIView {
     let view = UIView()
     let animator = UIDynamicAnimator(referenceView: view)
     let gravity = UIGravityBehavior(items: animationViews)
-    
+
     let collision = UICollisionBehavior(items: animationViews)
-    collision.translatesReferenceBoundsIntoBoundary = true
-    
-    // バリアの設定
-    // TODO: 色々弾性の設定できそう
-    /// https://qiita.com/Hiragarian/items/15a0e4a1e1396059e21b
-//    let barrierRect = CGRect(x: 0, y: 0 - viewSize.height, width: viewSize.width, height: viewSize.height)
-//    collision.addBoundary(withIdentifier: "barrier" as NSCopying, for: UIBezierPath(rect: barrierRect))
-    
+    collision.translatesReferenceBoundsIntoBoundary = false
+
+    /// 衝突境界の設定　https://qiita.com/Hiragarian/items/15a0e4a1e1396059e21b
+    let adMargin: CGFloat = purchaseManager.isPurchasedProduct ? 0 : 50
+    let barrierRect = CGRect(x: 0, y: 0, width: viewWidth, height: viewHeight - adMargin)
+    collision.addBoundary(withIdentifier: "barrier" as NSCopying, for: UIBezierPath(rect: barrierRect))
+
     animator.addBehavior(collision)
     animator.addBehavior(gravity)
-    
+
     // ボタンを追加
     for animationView in animationViews {
       view.addSubview(animationView)
@@ -46,8 +53,8 @@ public struct GravityView: UIViewRepresentable {
 
   public func updateUIView(_ uiView: UIView, context: Context) {
     // ボタンが追加または削除された場合の更新処理
-    if context.coordinator.currentAnimationViews != animationViews {
-      context.coordinator.updateAnimator(animationViews, angle, in: uiView)
+    if context.coordinator.currentAnimationViews != animationViews || context.coordinator.parent.isPurchaseProduct != purchaseManager.isPurchasedProduct {
+      context.coordinator.updateAnimator(animationViews, angle, isPurchasePremium: purchaseManager.isPurchasedProduct, in: uiView)
     }
 
     // 端末の角度に変更があった場合の処理
@@ -61,39 +68,45 @@ public struct GravityView: UIViewRepresentable {
   }
     
   public class Coordinator: NSObject {
+    @EnvironmentObject var purchaseManager: InAppPurchaseManager
     var parent: GravityView
     var animator: UIDynamicAnimator?
-
     var currentAnimationViews: [UIView]
     var currentAngle: CGFloat
-
     var currentGravityBehavior: UIGravityBehavior
+    let viewWidth: CGFloat
+    let viewHeight: CGFloat
     
     init(_ parent: GravityView) {
       self.parent = parent
       self.currentAnimationViews = parent.animationViews
       self.currentAngle = parent.angle
       self.currentGravityBehavior = UIGravityBehavior(items: parent.animationViews)
+      self.viewWidth = parent.viewWidth
+      self.viewHeight = parent.viewHeight
     }
-    
+
     // Blockのアップデート
-    func updateAnimator(_ animationViews: [UIView], _ angle: CGFloat, in view: UIView) {
+    func updateAnimator(_ animationViews: [UIView], _ angle: CGFloat, isPurchasePremium: Bool, in view: UIView) {
       // 既存のBlockを削除
       view.subviews.forEach { $0.removeFromSuperview() }
       // Blockを追加
       for animationView in animationViews {
         view.addSubview(animationView)
       }
-      
+
       // Blockにアニメーターの動作を設定
       if let animator = animator {
         animator.removeAllBehaviors()
-        
+
         currentGravityBehavior = UIGravityBehavior(items: animationViews)
         currentGravityBehavior.angle = CGFloat(angle + CGFloat.pi / 2)
 
         let collision = UICollisionBehavior(items: animationViews)
-        collision.translatesReferenceBoundsIntoBoundary = true
+        collision.translatesReferenceBoundsIntoBoundary = false
+        let adMargin: CGFloat = isPurchasePremium ? 0 : 50
+        let barrierRect = CGRect(x: 0, y: 0, width: viewWidth, height: viewHeight - adMargin)
+        collision.addBoundary(withIdentifier: "barrier" as NSCopying, for: UIBezierPath(rect: barrierRect))
         
         animator.addBehavior(collision)
         animator.addBehavior(currentGravityBehavior)

--- a/Sources/CustomViewFeature/GravityView.swift
+++ b/Sources/CustomViewFeature/GravityView.swift
@@ -12,12 +12,10 @@ public struct GravityView: UIViewRepresentable {
   // TODO: 要検討：Bindingじゃなくて良いかも
   @Binding var animationViews: [UIView]
   @Binding var angle: CGFloat
-  let viewSize: CGSize
 
-  public init(animationViews: Binding<[UIView]>, angle: Binding<CGFloat>, viewSize: CGSize) {
+  public init(animationViews: Binding<[UIView]>, angle: Binding<CGFloat>) {
     self._animationViews = animationViews
     self._angle = angle
-    self.viewSize = viewSize
   }
 
   public func makeUIView(context: Context) -> UIView {

--- a/Sources/HomeFeature/HomeView.swift
+++ b/Sources/HomeFeature/HomeView.swift
@@ -102,8 +102,6 @@ public struct HomeView: View {
       initBlockViews()
     })
     .onChange(of: blockViews, { oldValue, newValue in
-      print("テスト \(newValue.count)")
-      print("テスト２ \(newValue)")
     })
     .preferredColorScheme(settings.isDarkMode ? .dark : .light)
   }
@@ -174,8 +172,6 @@ extension HomeView {
       let blockItemView = BlockItemView(item: item) { noteItem in
         self.editingNoteItem = noteItem
         self.isAddingNote = true
-        
-         print("テスト3 \(blockViews)")
       }
       if let blockView = UIHostingController(rootView: blockItemView).view {
         blockView.frame = CGRect(x: CGFloat.random(in: 0...300), y: 100, width: blockFrame, height: blockFrame)

--- a/Sources/HomeFeature/HomeView.swift
+++ b/Sources/HomeFeature/HomeView.swift
@@ -67,7 +67,6 @@ public struct HomeView: View {
           // 既存Itemの編集
           NoteView(noteItem: item, isEditNote: true) { newItem in
             saveItem(newItem)
-            addBlockViews(item: newItem)
             isAddingNote = false
             editingNoteItem = nil
           } onCancel: {

--- a/Sources/HomeFeature/HomeView.swift
+++ b/Sources/HomeFeature/HomeView.swift
@@ -41,66 +41,71 @@ public struct HomeView: View {
   }
 
   public var body: some View {
-    NavigationStack(path: $navigationPath) {
-      VStack {
-        GravityView(animationViews: $blockViews, angle: $motionManager.angle)
-        if !purchaseManager.isPurchasedProduct {
-          // バナー広告
-          BannerAdView()
-            .frame(height: 50, alignment: .center)
-        }
-      }
-      .onAppear {
-        if isFirstAppear {
-          initBlockViews()
-          isFirstAppear = false
-        }
-        motionManager.startDeviceMotionUpdates()
-        // TODO: 初回起動時はtutorial用のブロックを追加する（SwiftDataにも追加）
-        if settings.isFirstLaunch {
-          addTutorialBlock()
-          settings.isFirstLaunch = false
-        }
-      }
-      .fullScreenCover(isPresented: $isAddingNote) {
-        if let item = editingNoteItem {
-          // 既存Itemの編集
-          NoteView(noteItem: item, isEditNote: true) { newItem in
-            saveItem(newItem)
-            isAddingNote = false
-            editingNoteItem = nil
-          } onCancel: {
-            isAddingNote = false
-            editingNoteItem = nil
-          } onDelete: { item in
-            deleteNote(item)
-            removeBlockView(item: item)
-            isAddingNote = false
-            editingNoteItem = nil
-          }
-        } else {
-          // 新規Itemの追加
-          let initialItem: NoteItem = .init(title: "", content: "", hue: 0.5, saturation: 1, brightness: 1, systemIconName: "pencil", blockType: .note)
-          NoteView(noteItem: initialItem, isEditNote: false) { newItem in
-            saveItem(newItem)
-            addBlockViews(item: newItem)
-            isAddingNote = false
-          } onCancel: {
-            isAddingNote = false
-          } onDelete: { item in
-            isAddingNote = false
+    GeometryReader { geometry in
+      NavigationStack(path: $navigationPath) {
+        VStack {
+          GravityView(animationViews: $blockViews,
+                      angle: $motionManager.angle,
+                      viewWidth: geometry.size.width,
+                      viewHeight: geometry.size.height,
+                      isPurchaseProduct: purchaseManager.isPurchasedProduct)
+          
+          if !purchaseManager.isPurchasedProduct {
+            // バナー広告
+            BannerAdView()
+              .frame(height: 50, alignment: .center)
           }
         }
-      }
-      .navigationDestination(for: SettingView.self) { view in
-        view
+        .onAppear {
+          if isFirstAppear {
+            initBlockViews()
+            isFirstAppear = false
+          }
+          motionManager.startDeviceMotionUpdates()
+          // TODO: 初回起動時はtutorial用のブロックを追加する（SwiftDataにも追加）
+          if settings.isFirstLaunch {
+            addTutorialBlock()
+            settings.isFirstLaunch = false
+          }
+        }
+        .fullScreenCover(isPresented: $isAddingNote) {
+          if let item = editingNoteItem {
+            // 既存Itemの編集
+            NoteView(noteItem: item, isEditNote: true) { newItem in
+              saveItem(newItem)
+              isAddingNote = false
+              editingNoteItem = nil
+            } onCancel: {
+              isAddingNote = false
+              editingNoteItem = nil
+            } onDelete: { item in
+              deleteNote(item)
+              removeBlockView(item: item)
+              isAddingNote = false
+              editingNoteItem = nil
+            }
+          } else {
+            // 新規Itemの追加
+            let initialItem: NoteItem = .init(title: "", content: "", hue: 0.5, saturation: 1, brightness: 1, systemIconName: "pencil", blockType: .note)
+            NoteView(noteItem: initialItem, isEditNote: false) { newItem in
+              saveItem(newItem)
+              addBlockViews(item: newItem)
+              isAddingNote = false
+            } onCancel: {
+              isAddingNote = false
+            } onDelete: { item in
+              isAddingNote = false
+            }
+          }
+        }
+        .navigationDestination(for: SettingView.self) { view in
+          view
+        }
       }
     }
     .onChange(of: settings.blockSizeType, { _, _ in
       removeAllBlock()
       initBlockViews()
-    })
-    .onChange(of: blockViews, { oldValue, newValue in
     })
     .preferredColorScheme(settings.isDarkMode ? .dark : .light)
   }

--- a/Sources/HomeFeature/HomeView.swift
+++ b/Sources/HomeFeature/HomeView.swift
@@ -79,8 +79,8 @@ public struct HomeView: View {
               isAddingNote = false
               editingNoteItem = nil
             } onDelete: { item in
-              deleteNote(item)
               removeBlockView(item: item)
+              deleteNote(item)
               isAddingNote = false
               editingNoteItem = nil
             }

--- a/Sources/NoteFeature/NoteView.swift
+++ b/Sources/NoteFeature/NoteView.swift
@@ -11,8 +11,11 @@ import SwiftUI
 
 public struct NoteView: View {
   @EnvironmentObject var settings: AppSettingsService
-  @State public var noteItem: NoteItem
-  // @State private var temporaryNoteItem: NoteItem
+  // @State public var noteItem: NoteItem
+  
+  @State private var editedItem: NoteItem
+  
+  
   @FocusState private var focusedField: Field?
   @State private var isShowIconEditView = false
   let isEditNote: Bool
@@ -30,7 +33,8 @@ public struct NoteView: View {
               onSave: @escaping (NoteItem) -> Void,
               onCancel: @escaping () -> Void,
               onDelete: @escaping (NoteItem) -> Void) {
-    self.noteItem = noteItem
+    // self.noteItem = noteItem
+    self._editedItem = State(initialValue: noteItem)
     self.isEditNote = isEditNote
     self.onSave = onSave
     self.onCancel = onCancel
@@ -42,7 +46,7 @@ public struct NoteView: View {
       VStack {
         HStack {
           // タイトル入力
-          TextField("Title", text: $noteItem.title)
+          TextField("Title", text: $editedItem.title)
             .font(.custom(settings.fontType.rawValue, size: 24).bold())
             .padding()
             .focused($focusedField, equals: .title)
@@ -55,14 +59,14 @@ public struct NoteView: View {
           Button {
             isShowIconEditView = true
           } label: {
-            Image(systemName: noteItem.systemIconName)
+            Image(systemName: editedItem.systemIconName)
               .resizable()
               .aspectRatio(contentMode: .fit)
-              .foregroundStyle(noteItem.color.foregroundColor)
+              .foregroundStyle(editedItem.color.foregroundColor)
               .padding(12)
           }
           .frame(width: 48, height: 48)
-          .background(noteItem.color)
+          .background(editedItem.color)
           .clipShape(.rect(cornerRadius: 8))
           .padding(.horizontal, 32)
         }
@@ -70,11 +74,11 @@ public struct NoteView: View {
 
         // 本文入力
         ZStack(alignment: .topLeading) {
-          TextEditor(text:$noteItem.content)
+          TextEditor(text:$editedItem.content)
             .padding()
             .font(.custom(settings.fontType.rawValue, size: 16))
             .focused($focusedField, equals: .content)
-          if noteItem.content.isEmpty {
+          if editedItem.content.isEmpty {
             Text("Content")
               .font(.custom(settings.fontType.rawValue, size: 16).italic())
               .foregroundStyle(Color.gray.opacity(0.6))
@@ -88,7 +92,7 @@ public struct NoteView: View {
             Spacer()
             Button {
               // TODO: 削除確認アラートを表示
-              onDelete(noteItem)
+              onDelete(editedItem)
             } label: {
               Image(systemName: "trash")
             }
@@ -110,7 +114,7 @@ public struct NoteView: View {
         }
         ToolbarItem(placement: .topBarTrailing) {
           Button {
-            onSave(noteItem)
+            onSave(editedItem)
           } label: {
             Text("Save")
           }
@@ -118,7 +122,7 @@ public struct NoteView: View {
       }
     }
     .sheet(isPresented: $isShowIconEditView) {
-      EditIconView(noteItem: noteItem)
+      EditIconView(noteItem: editedItem)
     }
     .onAppear {
       if !isEditNote {


### PR DESCRIPTION
テキストの編集をキャンセルできるよう修正
→ .fullScreenSheetに値を渡すとBindingになっちゃってキャンセルできないのでHomeにeditingNoteItemを追加して対応

テキスト入力・編集時にHomeのアイコンが表示されなくなる事象の対応
→ GravityViewの衝突判定を明示しないとキーボード表示時に衝突判定が消えちゃうみたいだったので修正

広告削除後に重力設定をアップデートするよう調整

Itemの削除処理順を修正