### PR TITLE
アイコンのレイアウト調整

### DIFF
--- a/Sources/HomeFeature/BlockItemView.swift
+++ b/Sources/HomeFeature/BlockItemView.swift
@@ -30,7 +30,7 @@ public struct BlockItemView: View {
     }, label: {
       Image(systemName: item.systemIconName)
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .aspectRatio(contentMode: .fit)
         .foregroundColor(getForegroundColor(item: item))
         .padding(padding)
         .opacity(item.blockType == .tutorial && isBlinking ? 0 : 1)

--- a/Sources/NoteFeature/EditIconView.swift
+++ b/Sources/NoteFeature/EditIconView.swift
@@ -8,9 +8,11 @@
 import CustomViewFeature
 import Entities
 import Extensions
+import SettingsFeature
 import SwiftUI
 
 public struct EditIconView: View {
+  @EnvironmentObject var settings: AppSettingsService
   @Environment(\.dismiss) var dismiss
   @Bindable public var noteItem: NoteItem
 
@@ -38,12 +40,19 @@ public struct EditIconView: View {
           Image(systemName: systemImageString)
             .resizable()
             .aspectRatio(contentMode: .fit)
-            .padding(20)
+            .padding(settings.getBlockImagePadding())
             .foregroundStyle(backGroundColor.foregroundColor)
         }
-        .frame(width: 80, height: 80)
+        .frame(width: settings.getBlockFrame(), height: settings.getBlockFrame())
         .background(backGroundColor)
         .clipShape(.rect(cornerRadius: 8))
+        .overlay {
+          RoundedRectangle(cornerRadius: 8)
+            .stroke(lineWidth: 2)
+            .fill(
+              settings.isShowBlockBorder ? (settings.isDarkMode ? .white : .black) : .clear
+            )
+        }
         .padding(.trailing, 32)
         // カラーピッカー
         ColorPickerView(hue: $hue, saturation: $saturation, brightness: $brightness)

--- a/Sources/NoteFeature/SymbolSelectView.swift
+++ b/Sources/NoteFeature/SymbolSelectView.swift
@@ -33,7 +33,10 @@ struct SymbolSelectView: View {
               self.selectedSymbol = symbol
             } label: {
               Image(systemName: symbol)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
                 .foregroundColor(settings.isDarkMode ? .white : .black)
+                .padding(16)
             }
             .frame(width: itemSize, height: itemSize)
             .overlay {

--- a/Sources/SettingsFeature/BlockSettingView.swift
+++ b/Sources/SettingsFeature/BlockSettingView.swift
@@ -84,7 +84,7 @@ public struct BlockSettingView: View {
         Image(systemName: "checkmark")
           .resizable()
           .frame(width: 24, height: 24)
-          .aspectRatio(contentMode: .fill)
+          .aspectRatio(contentMode: .fit)
           .foregroundStyle(
             self.blockSizeType == type ? (settings.isDarkMode ? .white : .black) : .clear
           )
@@ -92,7 +92,7 @@ public struct BlockSettingView: View {
         Group {
           Image(systemName: "house")
             .resizable()
-            .aspectRatio(contentMode: .fill)
+            .aspectRatio(contentMode: .fit)
             .foregroundStyle(.black)
             .padding(blockPadding)
         }


### PR DESCRIPTION
アイコンによってHomeのBlock内のレイアウトがはみ出す事象の対応
アイコン選択Viewのアイコンが小さすぎたので対応